### PR TITLE
Update to more recent version of zig, implement decode some attributes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    const lib = b.addStaticLibrary("cf", "cf.zig");
+    lib.setBuildMode(mode);
+    lib.install();
+
+    const main_tests = b.addTest("cf.zig");
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+}

--- a/src/ClassFile.zig
+++ b/src/ClassFile.zig
@@ -227,7 +227,8 @@ pub fn getJavaSEVersion(self: ClassFile) GetJavaSEVersionError!JavaSEVersion {
 
 test "Decode ClassFile" {
     const harness = @import("../test/harness.zig");
-    var reader = harness.hello.fbs().reader();
+    var fbs = harness.hello.fbs();
+    var reader = fbs.reader();
 
     var cf = try ClassFile.decode(std.testing.allocator, reader);
     defer cf.deinit();
@@ -235,7 +236,8 @@ test "Decode ClassFile" {
 
 test "Encode ClassFile" {
     const harness = @import("../test/harness.zig");
-    var reader = harness.hello.fbs().reader();
+    var fbs = harness.hello.fbs();
+    var reader = fbs.reader();
 
     var joe_file = try std.fs.cwd().createFile("Hello.class", .{});
     defer joe_file.close();
@@ -246,6 +248,7 @@ test "Encode ClassFile" {
     try cf.encode(joe_file.writer());
 
     var end_result: [harness.hello.data.len]u8 = undefined;
-    try cf.encode(std.io.fixedBufferStream(&end_result).writer());
+    var res_fbs = std.io.fixedBufferStream(&end_result);
+    try cf.encode(res_fbs.writer());
     try std.testing.expectEqualSlices(u8, harness.hello.data, &end_result);
 }

--- a/src/ConstantPool.zig
+++ b/src/ConstantPool.zig
@@ -17,7 +17,7 @@ pub fn init(allocator: std.mem.Allocator, entry_count: u16) !*ConstantPool {
     return c;
 }
 
-pub fn get(self: ConstantPool, index: u16) Entry {
+pub fn get(self: *const ConstantPool, index: u16) Entry {
     return self.entries.items[index - 1];
 }
 

--- a/src/ConstantPool.zig
+++ b/src/ConstantPool.zig
@@ -40,10 +40,10 @@ pub fn Serialize(comptime T: type) type {
             value.constant_pool = constant_pool;
 
             inline for (std.meta.fields(T)[1..]) |field| {
-                @field(value, field.name) = switch (@typeInfo(field.field_type)) {
-                    .Int => try reader.readIntBig(field.field_type),
-                    .Enum => |info| @intToEnum(field.field_type, try reader.readIntBig(info.tag_type)),
-                    else => @compileError("Decode not implemented: " ++ @typeName(field.field_type)),
+                @field(value, field.name) = switch (@typeInfo(field.type)) {
+                    .Int => try reader.readIntBig(field.type),
+                    .Enum => |info| @intToEnum(field.type, try reader.readIntBig(info.tag_type)),
+                    else => @compileError("Decode not implemented: " ++ @typeName(field.type)),
                 };
             }
 
@@ -90,7 +90,7 @@ pub fn decodeEntry(self: ConstantPool, reader: anytype) !Entry {
     inline for (@typeInfo(Tag).Enum.fields) |f, i| {
         const this_tag_value = @field(Tag, f.name);
         if (tag == @enumToInt(this_tag_value)) {
-            const T = std.meta.fields(Entry)[i].field_type;
+            const T = std.meta.fields(Entry)[i].type;
             var value = if (@hasDecl(T, "decode")) try @field(T, "decode")(&self, reader) else try Serialize(T).decode(&self, reader);
             return @unionInit(Entry, f.name, value);
         }
@@ -363,17 +363,17 @@ pub const Entry = union(Tag) {
             if (@enumToInt(self) == @enumToInt(this_tag_value)) {
                 try writer.writeByte(@enumToInt(self));
 
-                const T = std.meta.fields(Entry)[i].field_type;
+                const T = std.meta.fields(Entry)[i].type;
                 var value = @field(self, f.name);
 
                 if (@hasDecl(T, "encode"))
                     return try @field(value, "encode")(writer);
 
                 inline for (std.meta.fields(T)[1..]) |field| {
-                    switch (@typeInfo(field.field_type)) {
-                        .Int => try writer.writeIntBig(field.field_type, @field(value, field.name)),
+                    switch (@typeInfo(field.type)) {
+                        .Int => try writer.writeIntBig(field.type, @field(value, field.name)),
                         .Enum => |info| try writer.writeIntBig(info.tag_type, @enumToInt(@field(value, field.name))),
-                        else => @compileError("Encode not implemented: " ++ @typeName(field.field_type)),
+                        else => @compileError("Encode not implemented: " ++ @typeName(field.type)),
                     }
                 }
             }

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -23,9 +23,9 @@ pub const AttributeInfo = union(enum) {
         var name = constant_pool.get(attribute_name_index).utf8.bytes;
 
         inline for (std.meta.fields(AttributeInfo)) |field| {
-            if (field.field_type == void) {} else {
-                if (std.mem.eql(u8, @field(field.field_type, "name"), name)) {
-                    return @unionInit(AttributeInfo, field.name, try @field(field.field_type, "decode")(constant_pool, allocator, fbs.reader()));
+            if (field.type == void) {} else {
+                if (std.mem.eql(u8, @field(field.type, "name"), name)) {
+                    return @unionInit(AttributeInfo, field.name, try @field(field.type, "decode")(constant_pool, allocator, fbs.reader()));
                 }
             }
         }
@@ -36,7 +36,7 @@ pub const AttributeInfo = union(enum) {
 
     pub fn calcAttrLen(self: AttributeInfo) u32 {
         inline for (std.meta.fields(AttributeInfo)) |field| {
-            if (field.field_type == void) continue;
+            if (field.type == void) continue;
 
             if (std.meta.activeTag(self) == @field(std.meta.Tag(AttributeInfo), field.name)) {
                 return @field(self, field.name).calcAttrLen() + 6; // 6 intro bytes!
@@ -48,7 +48,7 @@ pub const AttributeInfo = union(enum) {
 
     pub fn deinit(self: *AttributeInfo) void {
         inline for (std.meta.fields(AttributeInfo)) |field| {
-            if (field.field_type == void) continue;
+            if (field.type == void) continue;
 
             if (std.meta.activeTag(self.*) == @field(std.meta.Tag(AttributeInfo), field.name)) {
                 @field(self, field.name).deinit();
@@ -58,12 +58,12 @@ pub const AttributeInfo = union(enum) {
 
     pub fn encode(self: AttributeInfo, writer: anytype) !void {
         inline for (std.meta.fields(AttributeInfo)) |field| {
-            if (field.field_type == void) continue;
+            if (field.type == void) continue;
 
             if (std.meta.activeTag(self) == @field(std.meta.Tag(AttributeInfo), field.name)) {
                 var attr = @field(self, field.name);
 
-                try writer.writeIntBig(u16, try attr.constant_pool.locateUtf8Entry(@field(field.field_type, "name")));
+                try writer.writeIntBig(u16, try attr.constant_pool.locateUtf8Entry(@field(field.type, "name")));
                 try writer.writeIntBig(u32, attr.calcAttrLen());
 
                 try attr.encode(writer);

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -7,6 +7,7 @@ const logger = std.log.scoped(.cf_attributes);
 pub const AttributeInfo = union(enum) {
     constant_value: ConstantValueAttribute,
     runtime_visible_annotations: RuntimeVisibleAnnotationsAttribute,
+    deprecated: DeprecatedAttribute,
     code: CodeAttribute,
     line_number_table: LineNumberTableAttribute,
     source_file: SourceFileAttribute,
@@ -342,6 +343,36 @@ pub const ConstantValueAttribute = struct {
         _ = self;
     }
 };
+
+pub const DeprecatedAttribute = struct {
+    pub const name = "Deprecated";
+
+    allocator: std.mem.Allocator,
+    constant_pool: *ConstantPool,
+
+    pub fn decode(constant_pool: *ConstantPool, allocator: std.mem.Allocator, reader: anytype) !DeprecatedAttribute {
+        _ = reader;
+        return DeprecatedAttribute{
+            .allocator = allocator,
+            .constant_pool = constant_pool,
+        };
+    }
+
+    pub fn calcAttrLen(self: DeprecatedAttribute) u32 {
+        _ = self;
+        return 2;
+    }
+
+    pub fn encode(self: DeprecatedAttribute, writer: anytype) anyerror!void {
+        _ = self;
+        _ = writer;
+    }
+
+    pub fn deinit(self: *DeprecatedAttribute) void {
+        _ = self;
+    }
+};
+
 // Annotations
 pub const ElementTag = enum(u8) {
     // Primitive types

--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -5,6 +5,7 @@ const logger = std.log.scoped(.cf_attributes);
 
 // TODO: Implement all attribute types
 pub const AttributeInfo = union(enum) {
+    constant_value: ConstantValueAttribute,
     code: CodeAttribute,
     line_number_table: LineNumberTableAttribute,
     source_file: SourceFileAttribute,
@@ -307,5 +308,36 @@ pub const ExceptionsAttribute = struct {
 
     pub fn deinit(self: *ExceptionsAttribute) void {
         self.exception_index_table.deinit(self.allocator);
+    }
+};
+
+pub const ConstantValueAttribute = struct {
+    pub const name = "ConstantValue";
+
+    allocator: std.mem.Allocator,
+    constant_pool: *ConstantPool,
+
+    constantvalue_index: u16,
+
+    pub fn decode(constant_pool: *ConstantPool, allocator: std.mem.Allocator, reader: anytype) !ConstantValueAttribute {
+        return ConstantValueAttribute{
+            .allocator = allocator,
+            .constant_pool = constant_pool,
+
+            .constantvalue_index = try reader.readIntBig(u16),
+        };
+    }
+
+    pub fn calcAttrLen(self: ConstantValueAttribute) u32 {
+        _ = self;
+        return 2;
+    }
+
+    pub fn encode(self: ConstantValueAttribute, writer: anytype) anyerror!void {
+        try writer.writeIntBig(u16, self.constantvalue_index);
+    }
+
+    pub fn deinit(self: *ConstantValueAttribute) void {
+        _ = self;
     }
 };

--- a/src/bytecode/ops.zig
+++ b/src/bytecode/ops.zig
@@ -599,7 +599,7 @@ pub const Operation = union(Opcode) {
     pub fn sizeOf(self: Operation) usize {
         inline for (std.meta.fields(Operation)) |op| {
             if (@enumToInt(std.meta.stringToEnum(Opcode, op.name).?) == @enumToInt(self)) {
-                return 1 + if (op.field_type == void) 0 else @sizeOf(op.field_type);
+                return 1 + if (op.type == void) 0 else @sizeOf(op.type);
             }
         }
 
@@ -647,9 +647,9 @@ pub const Operation = union(Opcode) {
 
             inline for (std.meta.fields(Operation)) |op| {
                 if (@enumToInt(std.meta.stringToEnum(Opcode, op.name).?) == opcode) {
-                    return @unionInit(Operation, op.name, if (op.field_type == void) {} else if (@typeInfo(op.field_type) == .Struct) z: {
-                        break :z if (@hasDecl(op.field_type, "decode")) try @field(op.field_type, "decode")(allocator, reader) else unreachable;
-                    } else if (@typeInfo(op.field_type) == .Enum) try reader.readEnum(op.field_type, .Big) else if (@typeInfo(op.field_type) == .Int) try reader.readIntBig(op.field_type) else unreachable);
+                    return @unionInit(Operation, op.name, if (op.type == void) {} else if (@typeInfo(op.type) == .Struct) z: {
+                        break :z if (@hasDecl(op.type, "decode")) try @field(op.type, "decode")(allocator, reader) else unreachable;
+                    } else if (@typeInfo(op.type) == .Enum) try reader.readEnum(op.type, .Big) else if (@typeInfo(op.type) == .Int) try reader.readIntBig(op.type) else unreachable);
                 }
             }
         }
@@ -695,12 +695,12 @@ pub const Operation = union(Opcode) {
 
         inline for (std.meta.fields(Operation)) |op| {
             if (@enumToInt(std.meta.stringToEnum(Opcode, op.name).?) == @enumToInt(self)) {
-                switch (op.field_type) {
+                switch (op.type) {
                     void => {},
-                    else => switch (@typeInfo(op.field_type)) {
-                        .Struct => if (@hasDecl(op.field_type, "encode")) try @field(@field(self, op.name), "encode")(writer) else unreachable,
-                        .Enum => try writer.writeIntBig(@typeInfo(op.field_type).Enum.tag_type, @enumToInt(@field(self, op.name))),
-                        .Int => try writer.writeIntBig(op.field_type, @field(self, op.name)),
+                    else => switch (@typeInfo(op.type)) {
+                        .Struct => if (@hasDecl(op.type, "encode")) try @field(@field(self, op.name), "encode")(writer) else unreachable,
+                        .Enum => try writer.writeIntBig(@typeInfo(op.type).Enum.tag_type, @enumToInt(@field(self, op.name))),
+                        .Int => try writer.writeIntBig(op.type, @field(self, op.name)),
                         else => unreachable,
                     },
                 }

--- a/src/bytecode/ops.zig
+++ b/src/bytecode/ops.zig
@@ -720,7 +720,8 @@ pub fn getIndex(inst: anytype) u16 {
 test "Decode and encode opcodes including wides" {
     const ClassFile = @import("../ClassFile.zig");
     const harness = @import("../../test/harness.zig");
-    var reader = harness.wide.fbs().reader();
+    var wide_fbs = harness.wide.fbs();
+    var reader = wide_fbs.reader();
 
     var cf = try ClassFile.decode(std.testing.allocator, reader);
     defer cf.deinit();

--- a/src/bytecode/wrapped.zig
+++ b/src/bytecode/wrapped.zig
@@ -97,12 +97,12 @@ pub const WrappedOperation = union(enum) {
 };
 
 pub const NoOperation = struct {
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return opcode == .nop;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) NoOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) NoOperation {
         _ = op;
         _ = opcode;
         _ = operation_field;
@@ -125,12 +125,12 @@ pub const PushConstantOperation = union(enum) {
     float: u2,
     double: u1,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return @enumToInt(opcode) >= 0x01 and @enumToInt(opcode) <= 0x11;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) PushConstantOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) PushConstantOperation {
         _ = operation_field;
 
         return switch (opcode) {
@@ -187,12 +187,12 @@ pub const LoadConstantOperation = struct {
     size: ConstantSize,
     index: u16,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return opcode == .ldc or opcode == .ldc_w or opcode == .ldc2_w;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) LoadConstantOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) LoadConstantOperation {
         _ = opcode;
         _ = operation_field;
         return .{
@@ -229,12 +229,12 @@ pub const StoreLocalOperation = struct {
     kind: BytecodePrimitive,
     index: u16,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = opcode;
         return operation_field.name.len >= "astore".len and std.mem.eql(u8, operation_field.name[1 .. 1 + "store".len], "store");
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) StoreLocalOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) StoreLocalOperation {
         _ = opcode;
         return .{
             .kind = BytecodePrimitive.fromShorthand(operation_field.name[0]),
@@ -259,12 +259,12 @@ pub const LoadLocalOperation = struct {
     kind: BytecodePrimitive,
     index: u16,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = opcode;
         return operation_field.name.len >= "aload".len and std.mem.eql(u8, operation_field.name[1 .. 1 + "load".len], "load");
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) LoadLocalOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) LoadLocalOperation {
         _ = opcode;
         return .{
             .kind = BytecodePrimitive.fromShorthand(operation_field.name[0]),
@@ -299,12 +299,12 @@ pub const NumericalOperation = struct {
     kind: BytecodePrimitive,
     operator: NumericalOperator,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return @enumToInt(opcode) >= 0x60 and @enumToInt(opcode) <= 0x77;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) NumericalOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) NumericalOperation {
         _ = op;
         _ = opcode;
         return .{
@@ -315,7 +315,7 @@ pub const NumericalOperation = struct {
 };
 
 test "Wrapped: Numerical" {
-    var add_op = ops.Operation{ .iadd = .{} };
+    var add_op = ops.Operation{ .iadd = {} };
     var add_wrapped = WrappedOperation.wrap(add_op);
 
     try std.testing.expectEqual(BytecodePrimitive.int, add_wrapped.numerical.kind);
@@ -326,12 +326,12 @@ pub const IncrementOperation = struct {
     index: u16,
     by: i16,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return opcode == .iinc;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) IncrementOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) IncrementOperation {
         _ = opcode;
         _ = operation_field;
         return .{
@@ -345,12 +345,12 @@ pub const ConvertOperation = struct {
     from: BytecodePrimitive,
     to: BytecodePrimitive,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return @enumToInt(opcode) >= 0x85 and @enumToInt(opcode) <= 0x93;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) ConvertOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) ConvertOperation {
         _ = op;
         _ = opcode;
         return .{
@@ -377,12 +377,12 @@ test "Wrapped: Convert" {
 pub const ReturnOperation = struct {
     kind: ?BytecodePrimitive,
 
-    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) bool {
+    fn matches(comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) bool {
         _ = operation_field;
         return @enumToInt(opcode) >= 0xac and @enumToInt(opcode) <= 0xb1;
     }
 
-    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.TypeInfo.UnionField) ReturnOperation {
+    fn wrap(op: ops.Operation, comptime opcode: ops.Opcode, comptime operation_field: std.builtin.Type.UnionField) ReturnOperation {
         _ = op;
         _ = opcode;
         return .{

--- a/src/bytecode/wrapped.zig
+++ b/src/bytecode/wrapped.zig
@@ -78,8 +78,8 @@ pub const WrappedOperation = union(enum) {
             comptime var opcode = @field(ops.Opcode, operation_field.name);
             if (std.meta.activeTag(op) == opcode) {
                 inline for (std.meta.fields(WrappedOperation)) |wo_field| {
-                    if (comptime wo_field.field_type.matches(opcode, operation_field)) {
-                        return @unionInit(WrappedOperation, wo_field.name, wo_field.field_type.wrap(op, opcode, operation_field));
+                    if (comptime wo_field.type.matches(opcode, operation_field)) {
+                        return @unionInit(WrappedOperation, wo_field.name, wo_field.type.wrap(op, opcode, operation_field));
                     }
                 }
 

--- a/src/descriptors.zig
+++ b/src/descriptors.zig
@@ -40,7 +40,7 @@ pub const Descriptor = union(enum) {
     method: MethodDescriptor,
 
     /// Only valid for method `return_type`s
-    @"void": void,
+    void: void,
 
     pub fn stringify(self: Self, writer: anytype) anyerror!void {
         switch (self) {
@@ -164,7 +164,7 @@ fn parse_(allocator: std.mem.Allocator, reader: anytype) anyerror!?*Descriptor {
             var returnd = (try parse_(allocator, reader)).?;
 
             var x = try allocator.create(Descriptor);
-            x.* = .{ .method = .{ .parameters = params.toOwnedSlice(), .return_type = returnd } };
+            x.* = .{ .method = .{ .parameters = try params.toOwnedSlice(), .return_type = returnd } };
             return x;
         },
         ')' => return null,
@@ -214,7 +214,7 @@ test "Descriptors: Write/parse method that returns an object and accepts an inte
 
     var object = Descriptor{ .object = "java/lang/Object" };
 
-    var desc = Descriptor{ .method = .{ .parameters = &.{ &int, &double, &thread }, .return_type = &object } };
+    var desc = Descriptor{ .method = .{ .parameters = &[_]*Descriptor{ &int, &double, &thread }, .return_type = &object } };
 
     var out_buf = std.ArrayList(u8).init(std.testing.allocator);
     defer out_buf.deinit();


### PR DESCRIPTION
Implementing the `DeprecatedAttribute` stopped `class2zig` from erroring out from malformed data when running on `java.lang.System`. 